### PR TITLE
Merge fix

### DIFF
--- a/src/cr5_driver/cr5_driver/tcp/feedback_client.py
+++ b/src/cr5_driver/cr5_driver/tcp/feedback_client.py
@@ -35,7 +35,7 @@ class DobotFeedbackClient:
 
     Extend by overriding the hook methods:
         _on_connect, _on_disconnect, _on_error, _on_message
-Dev
+
     """
 
     _instance: Optional[Self] = None

--- a/src/cr5_driver/cr5_driver/tcp/feedback_client.py
+++ b/src/cr5_driver/cr5_driver/tcp/feedback_client.py
@@ -35,7 +35,7 @@ class DobotFeedbackClient:
 
     Extend by overriding the hook methods:
         _on_connect, _on_disconnect, _on_error, _on_message
-
+Dev
     """
 
     _instance: Optional[Self] = None
@@ -49,7 +49,7 @@ class DobotFeedbackClient:
 
     def __new__(cls, host: Optional[str] = None,
                 log: Optional[RcutilsLogger] = None,
-                port: int = 29999) -> Self:
+                port: int = 30004) -> Self:
 
         if cls._instance is None:
             if host is None or log is None:
@@ -65,7 +65,7 @@ class DobotFeedbackClient:
             self,
             host: Optional[str] = None,
             log: Optional[RcutilsLogger] = None,
-            port: int = 29999,
+            port: int = 30004,
             buffer_size: int = 1440) -> None:
         """
         Initialise the feedback client.
@@ -227,14 +227,15 @@ class DobotFeedbackClient:
             while self._is_running:
                 time_since_last: float = (
                     time.monotonic() - self._last_valid_packet_time)
-
-                if time_since_last > self._watchdog_threshold:
+                # Log once per second to avoid flooding
+                if (
+                        time_since_last > self._watchdog_threshold
+                        and int(time_since_last) > int(time_since_last - 0.008)
+                ):
                     self._log.error(
-                        'Watchdog Triggered: No valid data for' +
-                        f' {time_since_last:.3f}s'
+                        f'Watchdog triggered: no valid data for '
+                        f'{time_since_last:.3f}s'
                     )
-
-                    self._last_valid_packet_time = time.monotonic()
                 try:
                     chunk: bytes = self._socket.recv(4096)
                     if not chunk:
@@ -248,13 +249,13 @@ class DobotFeedbackClient:
                     msg_size = struct.unpack_from('<H', stream_buffer, 0)[0]
 
                     if msg_size == self._buffer_size:
-                        self._last_valid_packet_time = time.monotonic()
+                        # self._last_valid_packet_time = time.monotonic()
                         if len(stream_buffer) >= (self._buffer_size * 2):
                             del stream_buffer[:self._buffer_size]
                             continue
 
                         packet = bytes(stream_buffer[:self._buffer_size])
-                        self._last_valid_packet_time = time.monotonic()
+                        # self._last_valid_packet_time = time.monotonic()
 
                         self._on_message(packet, (self._host, self._port))
                         del stream_buffer[:self._buffer_size]
@@ -288,6 +289,8 @@ class DobotFeedbackClient:
         """
         try:
             self._message = DobotFeedbackModel.from_bytes(raw_data)
+
+            self._last_valid_packet_time = time.monotonic()
 
             if self._callbacks:
                 for publish in self._callbacks:


### PR DESCRIPTION
feat(phase-1): complete TCP driver for Dobot CR5

## Summary
Complete from-scratch ROS2 TCP/IP driver for the Dobot CR5 collaborative
robot arm. All packages built without vendor code except the URDF.

## Packages Added

### cr5_msgs
- RobotState.msg -- robot operational status
- CartesianPose.msg -- Cartesian pose representation  
- EnableRobot.srv, DisableRobot.srv, ClearError.srv
- SetSpeed.srv, SetPayload.srv, SetMotionParams.srv
- EmptyRequest.srv -- generic request/response
- RobotMode enum -- all 11 CR5 operating modes
- DashboardErrorCode enum -- full error code mapping from protocol V4.6.5

### cr5_driver TCP Layer
- DobotFeedbackModel -- immutable dataclass parsing 1440-byte binary packets
  using byte offsets from Dobot TCP-IP Protocol V4.6.5 Section 3
- DobotDashboardModel -- immutable dataclass parsing ASCII command responses
- DobotFeedbackClient -- singleton, callback-based, persistent stream buffer
  with sync recovery, running at ~125Hz
- DobotDashboardClient -- singleton, thread-safe lock, port 29999,
  RequestControl() sent on connect

### cr5_driver ROS2 Layer
- JointStatePublisher -- /cr5/joint_states, BEST_EFFORT QoS, degrees to radians
- RobotStatePublisher -- /cr5/robot_state, operational status only
- ControlService -- enable, disable, clear_error, stop, pause, continue,
  request_control, e_stop/activate, e_stop/release, drag/enable, drag/disable
- SettingsService -- set_speed, set_payload, set_motion_params (AccJ/AccL/VelJ/VelL/CP)
- DriverNode -- MultiThreadedExecutor, ReentrantCallbackGroup

## Key Technical Decisions
- Singleton pattern via __new__ for both TCP clients -- no argument passing
- Callback registration on FeedbackClient -- publishers self-register
- Persistent stream buffer with magic header sync recovery
- Thread lock on DashboardClient -- safe concurrent service calls
- Second port 29999 connection planned for Phase 3 ros2_control ServoJ

## Tested Against Real Hardware
- Robot: Dobot CR5 at 192.168.0.141
- /cr5/joint_states publishing at ~121Hz
- All 11 control services responding correctly
- Packet integrity validated via TestValue field (0x0123456789ABCDEF)
- J1 = 1.0 deg verified: ROS2 reports 0.01745 rad ✓

## Closes
Closes #7 -- cr5_msgs package
Closes #8 -- DashboardClient port 29999
Closes #9 -- FeedbackClient port 30004
Closes #10 -- FeedbackParser / FeedbackModel
Closes #11 -- /cr5/joint_states topic
Closes #12 -- enable/disable/clear_error services
Closes #14 -- unit tests (deleted -- architecture changed, will re-add Phase 2)

## Summary by Sourcery

Adjust Dobot CR5 feedback client networking and watchdog behavior to improve reliability and logging.

Bug Fixes:
- Correct the Dobot feedback TCP client to use the dedicated feedback port 30004 instead of the dashboard port 29999.
- Ensure the watchdog timer is updated only when valid feedback messages are successfully parsed, preventing false timeouts.

Enhancements:
- Throttle watchdog error logging to emit at most once per second to avoid log flooding from prolonged disconnects.